### PR TITLE
log-level: cloud.prefab and prefix tweaks

### DIFF
--- a/docs/explanations/bootstrapping.md
+++ b/docs/explanations/bootstrapping.md
@@ -36,7 +36,7 @@ with some combination of [Prefab Envs](/docs/explanations/defaults#prefab-enviro
 ## Helpful Logging
 
 Understanding which config your app is using can take some getting used to. To help Prefab has quite a lot of logging. 
-You can turn it all on with `log-level.prefab: debug` in your `.prefab.default.config.yaml`.
+You can turn it all on with `log-level.cloud.prefab: debug` in your `.prefab.default.config.yaml`.
 
 Here you can see the: key, value, type, match and source for each config value.
 The source tells us whether we are using a value from a config file or an API value. 
@@ -57,7 +57,7 @@ log-level                                          | debug                      
 log-level.app                                      | info                                | String  | Match: default                 | Source: remote_cdn_api
 log-level.app.controllers.documentation_controller | debug                               | String  | Match: default                 | Source: /Users/user/.prefab.overrides.config.yaml
 log-level.google.apis.core.http_command            | info                                | String  | Match: default                 | Source: ./.prefab.default.config.yaml
-log-level.prefab                                   | debug                               | String  | Match: default                 | Source: /Users/user/.prefab.overrides.config.yaml
+log-level.cloud.prefab                             | debug                               | String  | Match: default                 | Source: /Users/user/.prefab.overrides.config.yaml
 redis.url                                          | redis://localhost:6379              | String  | Match: env:Y                   | Source: remote_cdn_api
 ```
 

--- a/docs/explanations/bootstrapping.md
+++ b/docs/explanations/bootstrapping.md
@@ -48,7 +48,7 @@ INFO  2022-09-06 09:23:53 -0400: prefab:  Load /Users/user/.prefab.overrides.con
 DEBUG 2022-09-06 09:23:53 -0400: prefab:  Initialize ConfigClient: AcquiredWriteLock
 INFO  2022-09-06 09:23:55 -0400: prefab:  Found new checkpoint with highwater id 16621306673926944 from remote_cdn_api in project X environment: Y and namespace: 'myapp.web'
 INFO  2022-09-06 09:23:55 -0400: prefab:  Unlocked Config via remote_cdn_api
-INFO  2022-09-06 09:23:55 -0400: prefab:  
+INFO  2022-09-06 09:23:55 -0400: prefab:
 accounting.api-uage.error-on-unknown-project       | false                               | FalseCl | Match: default                 | Source: ./.prefab.default.config.yaml
 features.api-usage                                 | <Prefab::FeatureFlag: active: true, | Prefab: | Match: env:Y                   | Source: remote_cdn_api
 google.gcp.big-query.dataset_name                  | development_dataset                 | String  | Match: default                 | Source: ./.prefab.default.config.yaml
@@ -57,7 +57,7 @@ log-level                                          | debug                      
 log-level.app                                      | info                                | String  | Match: default                 | Source: remote_cdn_api
 log-level.app.controllers.documentation_controller | debug                               | String  | Match: default                 | Source: /Users/user/.prefab.overrides.config.yaml
 log-level.google.apis.core.http_command            | info                                | String  | Match: default                 | Source: ./.prefab.default.config.yaml
-log-level.cloud.prefab                             | debug                               | String  | Match: default                 | Source: /Users/user/.prefab.overrides.config.yaml
+log-level.cloud.prefab                             | debug                               | String  | Match: default                 | Source: ./.prefab.default.config.yaml
 redis.url                                          | redis://localhost:6379              | String  | Match: env:Y                   | Source: remote_cdn_api
 ```
 

--- a/docs/ruby-sdk/dynamic-log-levels.md
+++ b/docs/ruby-sdk/dynamic-log-levels.md
@@ -23,7 +23,7 @@ Next, we'll set the Rails logger to use our logger
 
 ```ruby
 #application.rb
-$prefab = Prefab::Client.new
+$prefab = Prefab::Client.new(options)
 Rails.logger = $prefab.log
 ```
 
@@ -33,15 +33,15 @@ Finally we can start adjusting log levels.
 #.prefab.default.config.yaml
 log-level:
   _: debug
-  prefab: debug
+  cloud.prefab: debug
   app.controllers.prefab_controller: debug
 ```
 
 Our results speak for themselves. You can see that we've enabled debug logging for the prefab internals, rails internals and our application code.
 
 ```shell
-DEBUG 2022-09-06 13:01:54 -0400: prefab.config.sse:  Received event: #<struct SSE::StreamEvent type=:message, id=nil, last_event_id=nil>
-DEBUG 2022-09-06 13:01:54 -0400: prefab.config_client.load_configs:  Checkpoint with highwater id 16621316872267098 from sse. No changes.
+DEBUG 2022-09-06 13:01:54 -0400: cloud.prefab.client.sse:  Received event: #<struct SSE::StreamEvent type=:message, id=nil, last_event_id=nil>
+DEBUG 2022-09-06 13:01:54 -0400: cloud.prefab.client.load_configs:  Checkpoint with highwater id 16621316872267098 from sse. No changes.
 DEBUG 2022-09-06 13:02:03 -0400:  active_support.log_subscriber.debug:    (1.0ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
 DEBUG 2022-09-06 13:02:03 -0400:  active_record.log_subscriber.log_query_source:   ↳ /Users/...
 WARN  2022-09-06 13:02:03 -0400:  app.controllers.prefab_controller.index: warn level logging
@@ -56,7 +56,7 @@ If we set our levels to `info`, we see much less logging.
 #.prefab.default.config.yaml
 log-level:
   _: info
-  prefab: info
+  cloud.prefab: info
   app.controllers.prefab_controller: info
 ```
 

--- a/docs/ruby-sdk/ruby.md
+++ b/docs/ruby-sdk/ruby.md
@@ -27,6 +27,8 @@ options = Prefab::Options.new(
   namespace: "",
   logdev: $stdout,
   log_formatter: Prefab::Options::DEFAULT_LOG_FORMATTER,
+  # Optional. `log_prefix` can prefix your log lines. `app.controllers.my_controller.index` would be `com.yourapp.app.controllers.my_controller.index`
+  log_prefix: "com.yourapp",
   # one of
   # - Prefab::Options::ON_NO_DEFAULT::RAISE -- raise an exception when no value or default is available
   # - Prefab::Options::ON_NO_DEFAULT::RETURN_NIL -- return nil if no value or default is available
@@ -115,7 +117,7 @@ Add the following:
 
 ```yaml
 # .prefab.default.config.yaml
-log-level.prefab: info
+log-level.cloud.prefab: info
 my-first-int-config: 30
 my-first-feature-flag: false
 ```
@@ -333,7 +335,7 @@ $prefab.enabled? "new-feature", any_consistent_id
 
 ## Debugging
 
-You can control the Prefab client's log level by changing the configuration value of `log-level.prefab`. In the rare
+You can control the Prefab client's log level by changing the configuration value of `log-level.cloud.prefab`. In the rare
 case that you are trying to debug issues that occur before this config file has been read, set env var
 
 ```bash


### PR DESCRIPTION
This updates the docs for the latest ruby version.

TODO: Make sure the java logger is using `cloud.prefab.client` as a prefix (or at least `cloud.prefab`)
