### PR TITLE
fix: proper LOCAL_ONLY example

### DIFF
--- a/docs/sdks/ruby.md
+++ b/docs/sdks/ruby.md
@@ -324,12 +324,11 @@ top.
 
 ### Test Setup
 
-Specify `LOCAL_ONLY` and use your [config.yaml file](/docs/explanations/architecture/bootstrapping).
+Specify `LOCAL_ONLY` via an env var and use your [config.yaml file](/docs/explanations/architecture/bootstrapping).
 
-```ruby
-options = Prefab::Options.new(data_sources: LOCAL_ONLY)
 
-$prefab = Prefab::Client.initialize(options)
+```sh
+export PREFAB_DATASOURCES='LOCAL_ONLY'
 ```
 
 If you need to test multiple scenarios that depend on a single config or feature key, you can use a mock or stub to change the Prefab value.


### PR DESCRIPTION
`Prefab::Options.new(data_sources: LOCAL_ONLY)` isn't valid at all:
* `data_sources` isn't a valid key
* `LOCAL_ONLY` should be a string, not a constant.

After further debugging, you can pass the following, however, you also then need to explicitly provide an API key here instead.
```ruby
Prefab::Options.new(prefab_datasources: 'LOCAL_ONLY')
```

As a result, I believe recommending that folks use the built in ENV var of `PREFAB_DATASOURCES` makes the most sense.