### PR TITLE
Context clarifications

### DIFF
--- a/docs/sdks/java.md
+++ b/docs/sdks/java.md
@@ -112,6 +112,7 @@ To finely-target configuration rule evaluation, we accept contextual information
 prefabCloudClient.configClient().getContextStore().addContext(
                       PrefabContext.newBuilder("User")
                         .put("name", user.getName())
+                        .put("key", user.getKey())
                         .build());
 ```
 

--- a/docs/sdks/javascript.md
+++ b/docs/sdks/javascript.md
@@ -84,8 +84,8 @@ const options = {
   apiKey: "YOUR_CLIENT_API_KEY",
   // highlight-start
   context: new Context({
-    user: { email: "test@example.com" },
-    device: { mobile: true },
+    user: { key: "abcdef", email: "test@example.com" },
+    device: { key: "hijklm", mobile: true },
   }),
   // highlight-end
 };

--- a/docs/sdks/node.md
+++ b/docs/sdks/node.md
@@ -54,17 +54,23 @@ Prefab supports [context](/docs/explanations/concepts/context) for intelligent r
 Given
 
 ```js
-const context = {
-  user: {
-    key: "some-unique-identifier",
-    email: "test@example.com",
-    isAdmin: false,
-  },
-  subscription: {
-    key: "sub-pro",
-    plan: "pro",
-  },
-};
+const context = new Map([
+  [
+    "user",
+    new Map([
+      ["key", "some-unique-identifier"],
+      ["country", "US"],
+    ]),
+  ],
+
+  [
+    "subscription",
+    new Map([
+      ["key", "pro-sub"],
+      ["plan", "pro"],
+    ]),
+  ],
+]);
 ```
 
 You can pass this in to each call

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -168,14 +168,15 @@ for the current user (and/or team, request, etc)
 ```python
 context = {
     "user": {
-        "id": 123,
+        "key": 123,
         "subscription_level": "pro",
         "email": "bob@example.com"
     },
     "team": {
-        "id": 432,
+        "key": 432,
     },
     "device": {
+        "key": "abcdef",
         "mobile": False
     }
 }
@@ -199,14 +200,15 @@ context that will be evaluated as the default argument to `context=` if none is 
 from prefab_cloud_python import Context
 context = {
     "user": {
-        "id": 123,
+        "key": 123,
         "subscription_level": "pro",
         "email": "bob@example.com"
     },
     "team": {
-        "id": 432,
+        "key": 432,
     },
     "device": {
+        "key": "abcdef",
         "mobile": False
     }
 }
@@ -231,14 +233,15 @@ from prefab_cloud_python import Client
 
 context = {
     "user": {
-        "id": 123,
+        "key": 123,
         "subscription_level": "pro",
         "email": "bob@example.com"
     },
     "team": {
-        "id": 432,
+        "key": 432,
     },
     "device": {
+        "key": "abcdef",
         "mobile": False
     }
 }

--- a/docs/sdks/react.md
+++ b/docs/sdks/react.md
@@ -82,8 +82,8 @@ import { PrefabProvider } from "@prefab-cloud/prefab-cloud-react";
 const WrappedApp = () => {
   // highlight-start
   const contextAttributes = {
-    user: { email: "jeffrey@example.com" },
-    subscription: { plan: "advanced" },
+    user: { key: "abcdef", email: "jeffrey@example.com" },
+    subscription: { key: "adv-sub", plan: "advanced" },
   };
   // highlight-end
 

--- a/docs/sdks/ruby.md
+++ b/docs/sdks/ruby.md
@@ -148,6 +148,7 @@ context = {
     key: 'team-abc',
   },
   device: {
+    key: "abcdef",
     mobile: true,
   }
 }
@@ -325,7 +326,6 @@ top.
 ### Test Setup
 
 Specify `LOCAL_ONLY` via an env var and use your [config.yaml file](/docs/explanations/architecture/bootstrapping).
-
 
 ```sh
 export PREFAB_DATASOURCES='LOCAL_ONLY'


### PR DESCRIPTION
- Fix node context example
- Use `key` consistently for contexts and add a tip
